### PR TITLE
fix: Resize navigation icons and fonts

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,19 +12,19 @@
     <div id="sidebar-overlay" class="fixed z-40 inset-0 bg-black/70 opacity-0 invisible transition-opacity duration-400"></div>
 
     <!-- Fixed navigational top bar -->
-    <nav class="flex justify-between items-center fixed top-2.5 left-2.5 right-2.5 pr-4 text-accent bg-primary sm:top-5 sm:left-5 sm:right-5">
+    <nav class="flex justify-between items-center fixed top-2.5 left-2.5 right-2.5 pr-4 text-accent bg-primary sm:top-3.5 sm:left-3.5 sm:right-3.5">
 
       <!-- [Left] Logo + Title -->
       <button class="group title flex items-center gap-1">
-        <img class="w-16 block group-hover:hidden" src="src/assets/icons/grid-column-right.png" alt="website logo">
-        <img class="w-16 hidden group-hover:block" src="src/assets/icons/grid-column-right-hover.png" alt="">
+        <img class="w-[52px] block group-hover:hidden" src="src/assets/icons/grid-column-right.png" alt="website logo">
+        <img class="w-[52px] hidden group-hover:block" src="src/assets/icons/grid-column-right-hover.png" alt="">
         <a href="#" class="title">MONOGRAM</a>
       </button>
 
-      <div class="flex gap-9">
+      <div class="flex gap-6">
 
         <!-- Nav links -->
-        <div class="hidden items-center gap-10 xl:flex">
+        <div class="hidden items-center gap-7 lg:flex">
           <a href="#" class="nav-link">HOW IT WORKS</a>
           
           <!-- Workflow dropdown -->
@@ -48,19 +48,19 @@
         <div class="flex items-center gap-3">
 
           <!-- Hambuger menu for mobile; should be hidden on larer screens -->
-          <button id="open-menu-btn" class="xl:hidden">
-            <img class="icon" src="src/assets/icons/menu.png" alt="hamburger menu">
+          <button id="open-menu-btn" class="lg:hidden">
+            <img class="w-9 cursor-pointer" src="src/assets/icons/menu.png" alt="hamburger menu">
           </button>
 
           <!-- Shopping icon -->
           <button class="">
-            <img class="w-10 cursor-pointer" src="src/assets/icons/shopping-bag.png" alt="shopping cart button">
+            <img class="w-8 cursor-pointer" src="src/assets/icons/shopping-bag.png" alt="shopping cart button">
           </button>
 
           <!-- Currency dropdown -->
             <button type="button" id="currency-dropdown-button">
-              <span class="title sm:hidden">$</span>
-              <span class="title link-dropdown hidden sm:block xl:font-light!">USD</span>
+              <span class="title link-dropdown sm:hidden">$</span>
+              <span class="title link-dropdown hidden sm:block lg:font-light!">USD</span>
             </button>
             <!-- Dropdown menu -->
             <div class="hidden">
@@ -78,31 +78,31 @@
     </nav>
   
     <!-- Mobile menu sidenav -->
-    <nav id="sidebar" class="flex flex-col gap-12 z-50 fixed top-0 left-0 w-[28rem] h-full p-5 text-accent bg-primary  transform -translate-x-full transition-transform duration-300 ease-in-out">
+    <nav id="sidebar" class="flex flex-col gap-3 z-50 fixed top-0 left-0 min-w-[22rem] h-full p-2 text-accent bg-primary transform -translate-x-full transition-transform duration-300 ease-in-out  sm:p-5">
 
       <div class="flex justify-between">
         <!-- [Left] Logo + Title -->
         <button class="group title flex items-center gap-1">
-          <img class="w-16 block group-hover:hidden" src="src/assets/icons/grid-column-right.png" alt="website logo">
-          <img class="w-16 hidden group-hover:block" src="src/assets/icons/grid-column-right-hover.png" alt="">
+          <img class="w-12 block group-hover:hidden" src="src/assets/icons/grid-column-right.png" alt="website logo">
+          <img class="w-12 hidden group-hover:block" src="src/assets/icons/grid-column-right-hover.png" alt="">
           <a href="#" class="title">MONOGRAM</a>
         </button>
         
         <!-- Close Button -->
         <!-- Added id="close-menu-btn" -->
         <button id="close-menu-btn">
-          <img class="w-9 cursor-pointer" src="src/assets/icons/x.png" alt="close menu sidebar button">
+          <img class="w-7 cursor-pointer" src="src/assets/icons/x.png" alt="close menu sidebar button">
         </button>    
       </div>
 
       <!-- Nav links -->
-      <div class="flex flex-col items-center gap-5 pl-18 text-left xl:flex">
+      <div class="flex flex-col items-center gap-3 pl-18 text-left xl:flex">
         <a href="#" class="nav-link sidenav-link">HOW IT WORKS</a>
         
         <!-- Workflow dropdown -->
         <button class="nav-link sidenav-link text-left">WORKFLOWS</button>
         <!-- Dropdown menu -->
-        <div class="flex flex-col gap-5 w-full pl-10">
+        <div class="flex flex-col gap-3 w-full pl-10">
           <a href="" class="nav-link sidenav-link">AUDIO CONSOLE</a>
           <a href="" class="nav-link sidenav-link">PHOTO CONSOLE</a>
           <a href="" class="nav-link sidenav-link">VIDEO CONSOLE</a>

--- a/src/style.css
+++ b/src/style.css
@@ -69,30 +69,23 @@
     /* Headings */
     .title {
         @apply
-            font-heading text-lg tracking-[0.12em]
+            font-heading text-sm tracking-[0.12em]
             cursor-pointer
             hover:text-hover;
-    }
-
-    /* Icons */
-    .icon {
-        @apply
-            w-12
-            cursor-pointer;
     }
 
     /* Links */
     .nav-link {
         @apply
-        font-light tracking-[0.12em]
+        font-light tracking-[0.12em] text-xs
         hover:text-hover;
     }
     /* Menu sidenav links */
     .sidenav-link {
         @apply
         w-full
-        pb-5
-        text-lg
+        pb-3
+        text-sm
         border-b-2 border-[#141c47];
     }
     /* Dropdown triangles */


### PR DESCRIPTION
## What's in this PR?

This PR makes every icon and text in the navigation section to be smaller and more in line with the original website.

Modified the menu sidenav's width from `w-[28rem]` to `w-[22rem]` to fit within mobile screens.

Also has the currency dropdown to have the triangle icon beside it on mobile screens.