### PR TITLE
feat: style product grids

### DIFF
--- a/index.html
+++ b/index.html
@@ -154,13 +154,13 @@
       </header>
 
       <!-- First grid -->
-      <section id="grid-featured" class="grid grid-cols-1 px-5 pt-5">
+      <section id="grid-featured" class="grid grid-cols-1 justify-items-center gap-5 px-5 pt-5 lg:pt-12">
         
         <!-- Grid items -->
         <!-- Prod1-->
-        <div class="relative">
+        <div class="relative sm:w-[31.5rem] lg:w-[33rem]">
           <!-- Pre-order sticker -->
-          <div class="absolute z-30 bg-ribbon">
+          <div class="pre-order">
             PRE-ORDER
           </div>
 
@@ -168,27 +168,27 @@
             <!-- Product image (main) -->
             <img class="w-full" src="src/assets/images/product/grid1/prod1/mockup-free-tXE-BU4gt9o-unsplash.jpg" alt="lip serum">
             <!-- Product image (hover) -->
-            <img class="w-full absolute top-0 left-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100" src="src/assets/images/product/grid1/prod1/mockup-free-CiiPxk2XKlY-unsplash.jpg" alt="lip serum">            
+            <img class="image-hover" src="src/assets/images/product/grid1/prod1/mockup-free-CiiPxk2XKlY-unsplash.jpg" alt="lip serum">            
           </div>
 
           <!-- Product name/Price/Description  -->
-          <div class="">
+          <div class="flex flex-col justify-end gap-0.5 mt-2 text-primary">
             <!-- Product + Price -->
-            <div class="">
+            <div class="flex justify-between">
               <h2>LIP SERUM</h2>
               <!-- Price/Buy Button -->
               <div class="">
-                <span>Sold Out</span>
-                <button>SHOP NOW</button>
+                <span class="sold-out">Sold Out</span>
+                <button class="hidden">SHOP NOW</button>
               </div>              
             </div>
-            <p>Serum for the lips.</p>
+            <p class="prod-desc">Serum for the lips.</p>
           </div>
         </div>
         <!-- Prod2 -->
         <div class="">
           <!-- Pre-order sticker -->
-          <div class="">
+          <div class="font-bold">
             PRE-ORDER
           </div>
 
@@ -196,7 +196,7 @@
             <!-- Product image (main) -->
             <img class="w-full" src="src/assets/images/product/grid1/prod2/mockup-free-m4p66uXKlW0-unsplash.jpg" alt="water bottle">
             <!-- Product image (hover) -->
-            <img class="w-full absolute top-0 left-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100" src="src/assets/images/product/grid1/prod2/mockup-free-RaZzLqfZ5TQ-unsplash.jpg" alt="water bottle">            
+            <img class="image-hover" src="src/assets/images/product/grid1/prod2/mockup-free-RaZzLqfZ5TQ-unsplash.jpg" alt="water bottle">            
           </div>
 
           <!-- Product name/Price/Description  -->
@@ -224,7 +224,7 @@
             <!-- Product image (main) -->
             <img class="w-full" src="src/assets/images/product/grid1/prod3/mockup-free-SVtnyhxhPKk-unsplash.jpg" alt="Cosmetic Travel Kit">
             <!-- Product image (hover) -->
-            <img class="w-full absolute top-0 left-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100" src="/src/assets/images/product/grid1/prod3/mockup-free-4opLIJTgMjM-unsplash.jpg" alt="Cosmetic Travel Kit">            
+            <img class="image-hover" src="/src/assets/images/product/grid1/prod3/mockup-free-4opLIJTgMjM-unsplash.jpg" alt="Cosmetic Travel Kit">            
           </div>
 
           <!-- Product name/Price/Description  -->
@@ -252,7 +252,7 @@
             <!-- Product image (main) -->
             <img class="w-full" src="src/assets/images/product/grid1/prod4/mockup-free-nbp_u-OemuE-unsplash.jpg" alt="Box">
             <!-- Product image (hover) -->
-            <img class="w-full absolute top-0 left-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100" src="src/assets/images/product/grid1/prod4/mockup-free-dKOM5Hwiphg-unsplash.jpg" alt="Box">            
+            <img class="image-hover" src="src/assets/images/product/grid1/prod4/mockup-free-dKOM5Hwiphg-unsplash.jpg" alt="Box">            
           </div>
 
           <!-- Product name/Price/Description  -->
@@ -280,7 +280,7 @@
             <!-- Product image (main) -->
             <img class="w-full" src="src/assets/images/product/grid1/prod5/mockup-free-isTYY86e514-unsplash.jpg" alt="Potato chips">
             <!-- Product image (hover) -->
-            <img class="w-full absolute top-0 left-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100" src="src/assets/images/product/grid1/prod5/mockup-free-BBUbUMxC_rc-unsplash.jpg" alt="Potato chips">            
+            <img class="image-hover" src="src/assets/images/product/grid1/prod5/mockup-free-BBUbUMxC_rc-unsplash.jpg" alt="Potato chips">            
           </div>
 
           <!-- Product name/Price/Description  -->
@@ -323,7 +323,7 @@
             <!-- Product image (main) -->
             <img class="w-full" src="src/assets/images/product/grid2/prod1/mockup-free-iGUjHhBdERk-unsplash.jpg" alt="Picture frame">
             <!-- Product image (hover) -->
-            <img class="w-full absolute top-0 left-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100" src="src/assets/images/product/grid2/prod1/mockup-free-um99wsqgd_0-unsplash.jpg" alt="Picture frame">            
+            <img class="image-hover" src="src/assets/images/product/grid2/prod1/mockup-free-um99wsqgd_0-unsplash.jpg" alt="Picture frame">            
           </div>
 
 
@@ -351,7 +351,7 @@
             <!-- Product image (main) -->
             <img class="w-full" src="src/assets/images/product/grid2/prod2/mockup-free-4iZzFDhS8X0-unsplash.jpg" alt="water bottle">
             <!-- Product image (hover) -->
-            <img class="w-full absolute top-0 left-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100" src="src/assets/images/product/grid2/prod2/mockup-free-lZC0QyruwK4-unsplash.jpg" alt="water bottle">            
+            <img class="image-hover" src="src/assets/images/product/grid2/prod2/mockup-free-lZC0QyruwK4-unsplash.jpg" alt="water bottle">            
           </div>
 
 
@@ -379,7 +379,7 @@
             <!-- Product image (main) -->
             <img class="w-full" src="src/assets/images/product/grid2/prod3/mockup-free-iWCJwcwxXy8-unsplash.jpg" alt="Tri-folding paper">
             <!-- Product image (hover) -->
-            <img class="w-full absolute top-0 left-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100" src="/src/assets/images/product/grid2/prod3/mockup-free-fs_J0oKCplE-unsplash.jpg" alt="Tri-folding paper">
+            <img class="image-hover" src="/src/assets/images/product/grid2/prod3/mockup-free-fs_J0oKCplE-unsplash.jpg" alt="Tri-folding paper">
           </div>
 
 
@@ -407,7 +407,7 @@
             <!-- Product image (main) -->
             <img class="w-full" src="src/assets/images/product/grid2/prod4/mockup-free-5nSwFqOyzHw-unsplash.jpg" alt="Cosmetic bottle">
             <!-- Product image (hover) -->
-            <img class="w-full absolute top-0 left-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100" src="src/assets/images/product/grid2/prod4/mockup-free-onBFHs-foB8-unsplash.jpg" alt="Cosmetic bottle">            
+            <img class="image-hover" src="src/assets/images/product/grid2/prod4/mockup-free-onBFHs-foB8-unsplash.jpg" alt="Cosmetic bottle">            
           </div>
 
 
@@ -435,7 +435,7 @@
             <!-- Product image (main) -->
             <img class="w-full" src="src/assets/images/product/grid2/prod5/mockup-free-Ux2iEN0g6Dc-unsplash.jpg" alt="Cotton swab">
             <!-- Product image (hover) -->
-            <img class="w-full absolute top-0 left-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100" src="src/assets/images/product/grid2/prod5/mockup-free-KiVoHBe8PJo-unsplash.jpg" alt="Cotton swab">            
+            <img class="image-hover" src="src/assets/images/product/grid2/prod5/mockup-free-KiVoHBe8PJo-unsplash.jpg" alt="Cotton swab">            
           </div>
 
 
@@ -463,7 +463,7 @@
             <!-- Product image (main) -->
             <img class="w-full" src="src/assets/images/product/grid2/prod6/mockup-free-3v0pXrjePss-unsplash.jpg" alt="Liquid dispenser">
             <!-- Product image (hover) -->
-            <img class="w-full absolute top-0 left-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100" src="src/assets/images/product/grid2/prod6/mockup-free--EaQgamAoIU-unsplash.jpg" alt="Liquid dispenser">            
+            <img class="image-hover" src="src/assets/images/product/grid2/prod6/mockup-free--EaQgamAoIU-unsplash.jpg" alt="Liquid dispenser">            
           </div>
 
 
@@ -491,7 +491,7 @@
             <!-- Product image (main) -->
             <img class="w-full" src="src/assets/images/product/grid2/prod7/mockup-free-Fez9sPtXOzM-unsplash.jpg" alt="Square dropper bottle">
             <!-- Product image (hover) -->
-            <img class="w-full absolute top-0 left-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100" src="src/assets/images/product/grid2/prod7/mockup-free-SUPEwMr-iCY-unsplash.jpg" alt="Square dropper bottle">            
+            <img class="image-hover" src="src/assets/images/product/grid2/prod7/mockup-free-SUPEwMr-iCY-unsplash.jpg" alt="Square dropper bottle">            
           </div>
 
 
@@ -519,7 +519,7 @@
             <!-- Product image (main) -->
             <img class="w-full" src="src/assets/images/product/grid2/prod8/mockup-free-R3fHo09P8FA-unsplash.jpg" alt="IPhone 15">
             <!-- Product image (hover) -->
-            <img class="w-full absolute top-0 left-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100" src="/src/assets/images/product/grid2/prod8/mockup-free-pHEtQf8Q5nk-unsplash.jpg" alt="IPhone 15">            
+            <img class="image-hover" src="/src/assets/images/product/grid2/prod8/mockup-free-pHEtQf8Q5nk-unsplash.jpg" alt="IPhone 15">            
           </div>
 
 
@@ -547,7 +547,7 @@
             <!-- Product image (main) -->
             <img class="w-full" src="src/assets/images/product/grid2/prod9/mockup-free-mbOA3KnbjdU-unsplash.jpg" alt="Liquid dispenser">
             <!-- Product image (hover) -->
-            <img class="w-full absolute top-0 left-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100" src="src/assets/images/product/grid2/prod9/mockup-free-RbN6PswtkKk-unsplash.jpg" alt="Liquid dispenser">            
+            <img class="image-hover" src="src/assets/images/product/grid2/prod9/mockup-free-RbN6PswtkKk-unsplash.jpg" alt="Liquid dispenser">            
           </div>
 
 
@@ -575,7 +575,7 @@
             <!-- Product image (main) -->
             <img class="w-full" src="src/assets/images/product/grid2/prod10/mockup-free-fQg-kHuqyPE-unsplash.jpg" alt="Lotion">
             <!-- Product image (hover) -->
-            <img class="w-full absolute top-0 left-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100" src="src/assets/images/product/grid2/prod10/mockup-free-dSN04rvRHh0-unsplash.jpg" alt="Lotion">            
+            <img class="image-hover" src="src/assets/images/product/grid2/prod10/mockup-free-dSN04rvRHh0-unsplash.jpg" alt="Lotion">            
           </div>
 
 
@@ -603,7 +603,7 @@
             <!-- Product image (main) -->
             <img class="w-full" src="src/assets/images/product/grid2/prod11/mockup-free-KV6ssi1shF0-unsplash.jpg" alt="Box">
             <!-- Product image (hover) -->
-            <img class="w-full absolute top-0 left-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100" src="src/assets/images/product/grid2/prod11/mockup-free-_AkQ57-2StI-unsplash.jpg" alt="Box">            
+            <img class="image-hover" src="src/assets/images/product/grid2/prod11/mockup-free-_AkQ57-2StI-unsplash.jpg" alt="Box">            
           </div>
 
 
@@ -631,7 +631,7 @@
             <!-- Product image (main) -->
             <img class="w-full" src="src/assets/images/product/grid2/prod12/mockup-free-ZK9Zvi55lPM-unsplash.jpg" alt="Airpods case">
             <!-- Product image (hover) -->
-            <img class="w-full absolute top-0 left-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100" src="src/assets/images/product/grid2/prod12/mockup-free-SLUg2UHeqPs-unsplash.jpg" alt="Airpods case">            
+            <img class="image-hover" src="src/assets/images/product/grid2/prod12/mockup-free-SLUg2UHeqPs-unsplash.jpg" alt="Airpods case">            
           </div>
 
 

--- a/index.html
+++ b/index.html
@@ -143,7 +143,7 @@
 
     <main>
       <!-- Hero (set background img) -->
-      <header class="hero-first flex flex-col justify-end items-center gap-11 h-[26rem] sm:h-[28rem] lg:gap-45 lg:h-[42rem]">
+      <header class="hero-first flex flex-col justify-end items-center gap-11 h-[26rem] sm:h-[27.5rem] lg:gap-45 lg:h-[42rem]">
           <div class="flex flex-col justify-center items-center gap-3.5 max-w-lg mx-auto px-[8%] text-accent text-center sm:px-[1%]">
             <h1 class="hero-heading">A CONSOLE FOR EVERY WORKFLOW</h1>
             <p class="subtitle">Discover the perfect console for yours.</p>          
@@ -154,11 +154,11 @@
       </header>
 
       <!-- First grid -->
-      <section id="grid-featured" class="grid grid-cols-1 justify-items-center gap-3.5 p-5 lg:grid-cols-2 lg:w-fit lg:mx-auto lg:pt-12">        
+      <section id="grid-featured" class="grid grid-cols-1 justify-items-center p-5 lg:grid-cols-2 lg:w-[54rem] lg:mx-auto lg:pt-12 grid:w-[70rem] xl:w-[72rem]">        
       
         <!-- Grid items -->
         <!-- Prod1-->
-        <div class="relative mb-5 sm:w-[31.5rem] lg:w-[25rem] grid:w-[33rem]">
+        <div class="relative mb-5 sm:w-[31.5rem] lg:w-[25rem] grid:w-[33rem] xl:w-[34rem]">
           <!-- Pre-order sticker -->
           <div class="pre-order">
             PRE-ORDER
@@ -168,7 +168,7 @@
             <!-- Product image (main) -->
             <img class="w-full" src="src/assets/images/product/grid1/prod1/mockup-free-tXE-BU4gt9o-unsplash.jpg" alt="lip serum">
             <!-- Product image (hover) -->
-            <img class="w-full absolute top-0 left-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100" src="src/assets/images/product/grid1/prod1/mockup-free-CiiPxk2XKlY-unsplash.jpg" alt="lip serum">            
+            <img class="image-hover" src="src/assets/images/product/grid1/prod1/mockup-free-CiiPxk2XKlY-unsplash.jpg" alt="lip serum">            
           </div>
 
           <!-- Product name/Price/Description  -->
@@ -186,7 +186,7 @@
           </div>
         </div>
         <!-- Prod2 -->
-        <div class="relative mb-5 sm:w-[31.5rem] lg:w-[25rem] grid:w-[33rem]">
+        <div class="relative mb-5 sm:w-[31.5rem] lg:w-[25rem] grid:w-[33rem] xl:w-[34rem]">
           <!-- Pre-order sticker -->
           <div class="pre-order">
             PRE-ORDER
@@ -196,7 +196,7 @@
             <!-- Product image (main) -->
             <img class="w-full" src="src/assets/images/product/grid1/prod2/mockup-free-m4p66uXKlW0-unsplash.jpg" alt="water bottle">
             <!-- Product image (hover) -->
-            <img class="w-full absolute top-0 left-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100" src="src/assets/images/product/grid1/prod2/mockup-free-RaZzLqfZ5TQ-unsplash.jpg" alt="water bottle">            
+            <img class="image-hover" src="src/assets/images/product/grid1/prod2/mockup-free-RaZzLqfZ5TQ-unsplash.jpg" alt="water bottle">            
           </div>
 
           <!-- Product name/Price/Description  -->
@@ -214,7 +214,7 @@
           </div>
         </div>
         <!-- Prod3 -->
-        <div class="relative mb-5 sm:w-[31.5rem] lg:w-[25rem] grid:w-[33rem]">
+        <div class="relative mb-5 sm:w-[31.5rem] lg:w-[25rem] grid:w-[33rem] xl:w-[34rem]">
           <!-- Pre-order sticker -->
           <div class="pre-order">
             PRE-ORDER
@@ -224,7 +224,7 @@
             <!-- Product image (main) -->
             <img class="w-full" src="src/assets/images/product/grid1/prod3/mockup-free-SVtnyhxhPKk-unsplash.jpg" alt="Cosmetic Travel Kit">
             <!-- Product image (hover) -->
-            <img class="w-full absolute top-0 left-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100" src="/src/assets/images/product/grid1/prod3/mockup-free-4opLIJTgMjM-unsplash.jpg" alt="Cosmetic Travel Kit">            
+            <img class="image-hover" src="/src/assets/images/product/grid1/prod3/mockup-free-4opLIJTgMjM-unsplash.jpg" alt="Cosmetic Travel Kit">            
           </div>
 
           <!-- Product name/Price/Description  -->
@@ -242,7 +242,7 @@
           </div>
         </div>
         <!-- Prod4 -->
-        <div class="relative mb-5 sm:w-[31.5rem] lg:w-[25rem] grid:w-[33rem]">
+        <div class="relative mb-5 sm:w-[31.5rem] lg:w-[25rem] grid:w-[33rem] xl:w-[34rem]">
           <!-- Pre-order sticker -->
           <div class="pre-order">
             PRE-ORDER
@@ -252,7 +252,7 @@
             <!-- Product image (main) -->
             <img class="w-full" src="src/assets/images/product/grid1/prod4/mockup-free-nbp_u-OemuE-unsplash.jpg" alt="Box">
             <!-- Product image (hover) -->
-            <img class="w-full absolute top-0 left-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100" src="src/assets/images/product/grid1/prod4/mockup-free-dKOM5Hwiphg-unsplash.jpg" alt="Box">            
+            <img class="image-hover" src="src/assets/images/product/grid1/prod4/mockup-free-dKOM5Hwiphg-unsplash.jpg" alt="Box">            
           </div>
 
           <!-- Product name/Price/Description  -->
@@ -270,17 +270,17 @@
           </div>
         </div>
         <!-- Prod5 (looooong) -->
-        <div class="relative mb-5 sm:w-[31.5rem] lg:w-[25rem] grid:w-[33rem]">
+        <div class="relative mb-5 sm:w-[31.5rem] lg:w-full lg:col-span-2">
           <!-- Pre-order sticker -->
           <div class="pre-order">
             PRE-ORDER
           </div>
 
-          <div class="group relative">
+          <div class="group relative lg:h-74 lg:object-cover grid:h-[26rem]">
             <!-- Product image (main) -->
-            <img class="w-full" src="src/assets/images/product/grid1/prod5/mockup-free-isTYY86e514-unsplash.jpg" alt="Potato chips">
+            <img class="w-full lg:h-74 lg:object-cover grid:h-[26rem]" src="src/assets/images/product/grid1/prod5/mockup-free-isTYY86e514-unsplash.jpg" alt="Potato chips">
             <!-- Product image (hover) -->
-            <img class="w-full absolute top-0 left-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100" src="src/assets/images/product/grid1/prod5/mockup-free-BBUbUMxC_rc-unsplash.jpg" alt="Potato chips">            
+            <img class="image-hover lg:h-74 lg:object-cover grid:h-[26rem]" src="src/assets/images/product/grid1/prod5/mockup-free-BBUbUMxC_rc-unsplash.jpg" alt="Potato chips">            
           </div>
 
           <!-- Product name/Price/Description  -->
@@ -309,11 +309,11 @@
       </section>
 
       <!-- Second grid -->
-      <section class="">
+      <section class="grid grid-cols-1 justify-items-center mx-auto p-5 lg:grid-cols-2 lg:w-[63rem] lg:pt-12 xl:grid-cols-3 xl:w-[73rem]">
 
         <!-- Grid items -->
         <!-- Prod1-->
-        <div class="relative mb-5 sm:w-[31.5rem] lg:w-[25rem] grid:w-[33rem]">
+        <div class="relative mb-5 sm:w-[31rem] lg:w-[27.5rem] xl:w-[20.5rem]">
           <!-- Pre-order sticker -->
           <div class="pre-order">
             PRE-ORDER
@@ -321,9 +321,9 @@
 
           <div class="group relative">
             <!-- Product image (main) -->
-            <img class="w-full" src="src/assets/images/product/grid2/prod1/mockup-free-iGUjHhBdERk-unsplash.jpg" alt="Picture frame">
+            <img class="w-full sm:w-[31rem] lg:h-[27.5rem] sm:object-cover xl:w-[20.5rem] xl:h-[20.5rem]" src="src/assets/images/product/grid2/prod1/mockup-free-iGUjHhBdERk-unsplash.jpg" alt="Picture frame">
             <!-- Product image (hover) -->
-            <img class="w-full absolute top-0 left-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100" src="src/assets/images/product/grid2/prod1/mockup-free-um99wsqgd_0-unsplash.jpg" alt="Picture frame">            
+            <img class="w-full absolute top-0 left-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100 sm:w-[31rem] lg:h-[27.5rem] sm:object-cover xl:w-[20.5rem] xl:h-[20.5rem]" src="src/assets/images/product/grid2/prod1/mockup-free-um99wsqgd_0-unsplash.jpg" alt="Picture frame">            
           </div>
 
 
@@ -341,7 +341,7 @@
           </div>
         </div>
         <!-- Prod2 -->
-        <div class="relative mb-5 sm:w-[31.5rem] lg:w-[25rem] grid:w-[33rem]">
+        <div class="relative mb-5 sm:w-[31rem] lg:w-[27.5rem] xl:w-[20.5rem]">
           <!-- Pre-order sticker -->
           <div class="pre-order">
             PRE-ORDER
@@ -349,9 +349,9 @@
 
           <div class="group relative">
             <!-- Product image (main) -->
-            <img class="w-full" src="src/assets/images/product/grid2/prod2/mockup-free-4iZzFDhS8X0-unsplash.jpg" alt="water bottle">
+            <img class="w-full sm:w-[31rem] lg:h-[27.5rem] sm:object-cover xl:w-[20.5rem] xl:h-[20.5rem]" src="src/assets/images/product/grid2/prod2/mockup-free-4iZzFDhS8X0-unsplash.jpg" alt="water bottle">
             <!-- Product image (hover) -->
-            <img class="w-full absolute top-0 left-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100" src="src/assets/images/product/grid2/prod2/mockup-free-lZC0QyruwK4-unsplash.jpg" alt="water bottle">            
+            <img class="w-full absolute top-0 left-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100 sm:w-[31rem] lg:h-[27.5rem] sm:object-cover xl:w-[20.5rem] xl:h-[20.5rem]" src="src/assets/images/product/grid2/prod2/mockup-free-lZC0QyruwK4-unsplash.jpg" alt="water bottle">            
           </div>
 
 
@@ -369,7 +369,7 @@
           </div>
         </div>
         <!-- Prod3 -->
-        <div class="relative mb-5 sm:w-[31.5rem] lg:w-[25rem] grid:w-[33rem]">
+        <div class="relative mb-5 sm:w-[31rem] lg:w-[27.5rem] xl:w-[20.5rem]">
           <!-- Pre-order sticker -->
           <div class="pre-order">
             PRE-ORDER
@@ -377,9 +377,9 @@
 
           <div class="group relative">
             <!-- Product image (main) -->
-            <img class="w-full" src="src/assets/images/product/grid2/prod3/mockup-free-iWCJwcwxXy8-unsplash.jpg" alt="Tri-folding paper">
+            <img class="w-full sm:w-[31rem] lg:h-[27.5rem] sm:object-cover xl:w-[20.5rem] xl:h-[20.5rem]" src="src/assets/images/product/grid2/prod3/mockup-free-iWCJwcwxXy8-unsplash.jpg" alt="Tri-folding paper">
             <!-- Product image (hover) -->
-            <img class="w-full absolute top-0 left-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100" src="/src/assets/images/product/grid2/prod3/mockup-free-fs_J0oKCplE-unsplash.jpg" alt="Tri-folding paper">
+            <img class="w-full absolute top-0 left-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100 sm:w-[31rem] lg:h-[27.5rem] sm:object-cover xl:w-[20.5rem] xl:h-[20.5rem]" src="/src/assets/images/product/grid2/prod3/mockup-free-fs_J0oKCplE-unsplash.jpg" alt="Tri-folding paper">
           </div>
 
 
@@ -397,7 +397,7 @@
           </div>
         </div>
         <!-- Prod4 -->
-        <div class="relative mb-5 sm:w-[31.5rem] lg:w-[25rem] grid:w-[33rem]">
+        <div class="relative mb-5 sm:w-[31rem] lg:w-[27.5rem] xl:w-[20.5rem]">
           <!-- Pre-order sticker -->
           <div class="pre-order">
             PRE-ORDER
@@ -405,9 +405,9 @@
 
           <div class="group relative">
             <!-- Product image (main) -->
-            <img class="w-full" src="src/assets/images/product/grid2/prod4/mockup-free-5nSwFqOyzHw-unsplash.jpg" alt="Cosmetic bottle">
+            <img class="w-full sm:w-[31rem] lg:h-[27.5rem] sm:object-cover xl:w-[20.5rem] xl:h-[20.5rem]" src="src/assets/images/product/grid2/prod4/mockup-free-5nSwFqOyzHw-unsplash.jpg" alt="Cosmetic bottle">
             <!-- Product image (hover) -->
-            <img class="w-full absolute top-0 left-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100" src="src/assets/images/product/grid2/prod4/mockup-free-onBFHs-foB8-unsplash.jpg" alt="Cosmetic bottle">            
+            <img class="w-full absolute top-0 left-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100 sm:w-[31rem] lg:h-[27.5rem] sm:object-cover xl:w-[20.5rem] xl:h-[20.5rem]" src="src/assets/images/product/grid2/prod4/mockup-free-onBFHs-foB8-unsplash.jpg" alt="Cosmetic bottle">            
           </div>
 
 
@@ -425,7 +425,7 @@
           </div>
         </div>
         <!-- Prod5 -->
-        <div class="relative mb-5 sm:w-[31.5rem] lg:w-[25rem] grid:w-[33rem]">
+        <div class="relative mb-5 sm:w-[31rem] lg:w-[27.5rem] xl:w-[20.5rem]">
           <!-- Pre-order sticker -->
           <div class="pre-order">
             PRE-ORDER
@@ -433,9 +433,9 @@
 
           <div class="group relative">
             <!-- Product image (main) -->
-            <img class="w-full" src="src/assets/images/product/grid2/prod5/mockup-free-Ux2iEN0g6Dc-unsplash.jpg" alt="Cotton swab">
+            <img class="w-full sm:w-[31rem] lg:h-[27.5rem] sm:object-cover xl:w-[20.5rem] xl:h-[20.5rem]" src="src/assets/images/product/grid2/prod5/mockup-free-Ux2iEN0g6Dc-unsplash.jpg" alt="Cotton swab">
             <!-- Product image (hover) -->
-            <img class="w-full absolute top-0 left-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100" src="src/assets/images/product/grid2/prod5/mockup-free-KiVoHBe8PJo-unsplash.jpg" alt="Cotton swab">            
+            <img class="w-full absolute top-0 left-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100 sm:w-[31rem] lg:h-[27.5rem] sm:object-cover xl:w-[20.5rem] xl:h-[20.5rem]" src="src/assets/images/product/grid2/prod5/mockup-free-KiVoHBe8PJo-unsplash.jpg" alt="Cotton swab">            
           </div>
 
 
@@ -453,7 +453,7 @@
           </div>
         </div>
         <!-- Prod6-->
-        <div class="relative mb-5 sm:w-[31.5rem] lg:w-[25rem] grid:w-[33rem]">
+        <div class="relative mb-5 sm:w-[31rem] lg:w-[27.5rem] xl:w-[20.5rem]">
           <!-- Pre-order sticker -->
           <div class="pre-order">
             PRE-ORDER
@@ -461,9 +461,9 @@
 
           <div class="group relative">
             <!-- Product image (main) -->
-            <img class="w-full" src="src/assets/images/product/grid2/prod6/mockup-free-3v0pXrjePss-unsplash.jpg" alt="Liquid dispenser">
+            <img class="w-full sm:w-[31rem] lg:h-[27.5rem] sm:object-cover xl:w-[20.5rem] xl:h-[20.5rem]" src="src/assets/images/product/grid2/prod6/mockup-free-3v0pXrjePss-unsplash.jpg" alt="Liquid dispenser">
             <!-- Product image (hover) -->
-            <img class="w-full absolute top-0 left-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100" src="src/assets/images/product/grid2/prod6/mockup-free--EaQgamAoIU-unsplash.jpg" alt="Liquid dispenser">            
+            <img class="w-full absolute top-0 left-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100 sm:w-[31rem] lg:h-[27.5rem] sm:object-cover xl:w-[20.5rem] xl:h-[20.5rem]" src="src/assets/images/product/grid2/prod6/mockup-free--EaQgamAoIU-unsplash.jpg" alt="Liquid dispenser">            
           </div>
 
 
@@ -481,7 +481,7 @@
           </div>
         </div>
         <!-- Prod7 -->
-        <div class="relative mb-5 sm:w-[31.5rem] lg:w-[25rem] grid:w-[33rem]">
+        <div class="relative mb-5 sm:w-[31rem] lg:w-[27.5rem] xl:w-[20.5rem]">
           <!-- Pre-order sticker -->
           <div class="pre-order">
             PRE-ORDER
@@ -489,9 +489,9 @@
 
           <div class="group relative">
             <!-- Product image (main) -->
-            <img class="w-full" src="src/assets/images/product/grid2/prod7/mockup-free-Fez9sPtXOzM-unsplash.jpg" alt="Square dropper bottle">
+            <img class="w-full sm:w-[31rem] lg:h-[27.5rem] sm:object-cover xl:w-[20.5rem] xl:h-[20.5rem]" src="src/assets/images/product/grid2/prod7/mockup-free-Fez9sPtXOzM-unsplash.jpg" alt="Square dropper bottle">
             <!-- Product image (hover) -->
-            <img class="w-full absolute top-0 left-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100" src="src/assets/images/product/grid2/prod7/mockup-free-SUPEwMr-iCY-unsplash.jpg" alt="Square dropper bottle">            
+            <img class="w-full absolute top-0 left-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100 sm:w-[31rem] lg:h-[27.5rem] sm:object-cover xl:w-[20.5rem] xl:h-[20.5rem]" src="src/assets/images/product/grid2/prod7/mockup-free-SUPEwMr-iCY-unsplash.jpg" alt="Square dropper bottle">            
           </div>
 
 
@@ -509,7 +509,7 @@
           </div>
         </div>
         <!-- Prod8 -->
-        <div class="relative mb-5 sm:w-[31.5rem] lg:w-[25rem] grid:w-[33rem]">
+        <div class="relative mb-5 sm:w-[31rem] lg:w-[27.5rem] xl:w-[20.5rem]">
           <!-- Pre-order sticker -->
           <div class="pre-order">
             PRE-ORDER
@@ -517,9 +517,9 @@
 
           <div class="group relative">
             <!-- Product image (main) -->
-            <img class="w-full" src="src/assets/images/product/grid2/prod8/mockup-free-R3fHo09P8FA-unsplash.jpg" alt="IPhone 15">
+            <img class="w-full sm:w-[31rem] lg:h-[27.5rem] sm:object-cover xl:w-[20.5rem] xl:h-[20.5rem]" src="src/assets/images/product/grid2/prod8/mockup-free-R3fHo09P8FA-unsplash.jpg" alt="IPhone 15">
             <!-- Product image (hover) -->
-            <img class="w-full absolute top-0 left-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100" src="/src/assets/images/product/grid2/prod8/mockup-free-pHEtQf8Q5nk-unsplash.jpg" alt="IPhone 15">            
+            <img class="w-full absolute top-0 left-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100 sm:w-[31rem] lg:h-[27.5rem] sm:object-cover xl:w-[20.5rem] xl:h-[20.5rem]" src="/src/assets/images/product/grid2/prod8/mockup-free-pHEtQf8Q5nk-unsplash.jpg" alt="IPhone 15">            
           </div>
 
 
@@ -537,7 +537,7 @@
           </div>
         </div>
         <!-- Prod9 -->
-        <div class="relative mb-5 sm:w-[31.5rem] lg:w-[25rem] grid:w-[33rem]">
+        <div class="relative mb-5 sm:w-[31rem] lg:w-[27.5rem] xl:w-[20.5rem]">
           <!-- Pre-order sticker -->
           <div class="pre-order">
             PRE-ORDER
@@ -545,9 +545,9 @@
 
           <div class="group relative">
             <!-- Product image (main) -->
-            <img class="w-full" src="src/assets/images/product/grid2/prod9/mockup-free-mbOA3KnbjdU-unsplash.jpg" alt="Liquid dispenser">
+            <img class="w-full sm:w-[31rem] lg:h-[27.5rem] sm:object-cover xl:w-[20.5rem] xl:h-[20.5rem]" src="src/assets/images/product/grid2/prod9/mockup-free-mbOA3KnbjdU-unsplash.jpg" alt="Liquid dispenser">
             <!-- Product image (hover) -->
-            <img class="w-full absolute top-0 left-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100" src="src/assets/images/product/grid2/prod9/mockup-free-RbN6PswtkKk-unsplash.jpg" alt="Liquid dispenser">            
+            <img class="w-full absolute top-0 left-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100 sm:w-[31rem] lg:h-[27.5rem] sm:object-cover xl:w-[20.5rem] xl:h-[20.5rem]" src="src/assets/images/product/grid2/prod9/mockup-free-RbN6PswtkKk-unsplash.jpg" alt="Liquid dispenser">            
           </div>
 
 
@@ -565,7 +565,7 @@
           </div>
         </div>
         <!-- Prod10 -->
-        <div class="relative mb-5 sm:w-[31.5rem] lg:w-[25rem] grid:w-[33rem]">
+        <div class="relative mb-5 sm:w-[31rem] lg:w-[27.5rem] xl:w-[20.5rem]">
           <!-- Pre-order sticker -->
           <div class="pre-order">
             PRE-ORDER
@@ -573,9 +573,9 @@
 
           <div class="group relative">
             <!-- Product image (main) -->
-            <img class="w-full" src="src/assets/images/product/grid2/prod10/mockup-free-fQg-kHuqyPE-unsplash.jpg" alt="Lotion">
+            <img class="w-full sm:w-[31rem] lg:h-[27.5rem] sm:object-cover xl:w-[20.5rem] xl:h-[20.5rem]" src="src/assets/images/product/grid2/prod10/mockup-free-fQg-kHuqyPE-unsplash.jpg" alt="Lotion">
             <!-- Product image (hover) -->
-            <img class="w-full absolute top-0 left-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100" src="src/assets/images/product/grid2/prod10/mockup-free-dSN04rvRHh0-unsplash.jpg" alt="Lotion">            
+            <img class="w-full absolute top-0 left-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100 sm:w-[31rem] lg:h-[27.5rem] sm:object-cover xl:w-[20.5rem] xl:h-[20.5rem]" src="src/assets/images/product/grid2/prod10/mockup-free-dSN04rvRHh0-unsplash.jpg" alt="Lotion">            
           </div>
 
 
@@ -593,7 +593,7 @@
           </div>
         </div>
         <!-- Prod11 -->
-        <div class="relative mb-5 sm:w-[31.5rem] lg:w-[25rem] grid:w-[33rem]">
+        <div class="relative mb-5 sm:w-[31rem] lg:w-[27.5rem] xl:w-[20.5rem]">
           <!-- Pre-order sticker -->
           <div class="pre-order">
             PRE-ORDER
@@ -601,9 +601,9 @@
 
           <div class="group relative">
             <!-- Product image (main) -->
-            <img class="w-full" src="src/assets/images/product/grid2/prod11/mockup-free-KV6ssi1shF0-unsplash.jpg" alt="Box">
+            <img class="w-full sm:w-[31rem] lg:h-[27.5rem] sm:object-cover xl:w-[20.5rem] xl:h-[20.5rem]" src="src/assets/images/product/grid2/prod11/mockup-free-KV6ssi1shF0-unsplash.jpg" alt="Box">
             <!-- Product image (hover) -->
-            <img class="w-full absolute top-0 left-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100" src="src/assets/images/product/grid2/prod11/mockup-free-_AkQ57-2StI-unsplash.jpg" alt="Box">            
+            <img class="w-full absolute top-0 left-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100 sm:w-[31rem] lg:h-[27.5rem] sm:object-cover xl:w-[20.5rem] xl:h-[20.5rem]" src="src/assets/images/product/grid2/prod11/mockup-free-_AkQ57-2StI-unsplash.jpg" alt="Box">            
           </div>
 
 
@@ -621,7 +621,7 @@
           </div>
         </div>
         <!-- Prod12 -->
-        <div class="relative mb-5 sm:w-[31.5rem] lg:w-[25rem] grid:w-[33rem]">
+        <div class="relative mb-5 sm:w-[31rem] lg:w-[27.5rem] xl:w-[20.5rem]">
           <!-- Pre-order sticker -->
           <div class="pre-order">
             PRE-ORDER
@@ -629,9 +629,9 @@
 
           <div class="group relative">
             <!-- Product image (main) -->
-            <img class="w-full" src="src/assets/images/product/grid2/prod12/mockup-free-ZK9Zvi55lPM-unsplash.jpg" alt="Airpods case">
+            <img class="w-full sm:w-[31rem] lg:h-[27.5rem] sm:object-cover xl:w-[20.5rem] xl:h-[20.5rem]" src="src/assets/images/product/grid2/prod12/mockup-free-ZK9Zvi55lPM-unsplash.jpg" alt="Airpods case">
             <!-- Product image (hover) -->
-            <img class="w-full absolute top-0 left-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100" src="src/assets/images/product/grid2/prod12/mockup-free-SLUg2UHeqPs-unsplash.jpg" alt="Airpods case">            
+            <img class="w-full absolute top-0 left-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100 sm:w-[31rem] lg:h-[27.5rem] sm:object-cover xl:w-[20.5rem] xl:h-[20.5rem]" src="src/assets/images/product/grid2/prod12/mockup-free-SLUg2UHeqPs-unsplash.jpg" alt="Airpods case">            
           </div>
 
 

--- a/index.html
+++ b/index.html
@@ -154,11 +154,11 @@
       </header>
 
       <!-- First grid -->
-      <section id="grid-featured" class="grid grid-cols-1 justify-items-center gap-5 px-5 pt-5 lg:pt-12">
-        
+      <section id="grid-featured" class="grid grid-cols-1 justify-items-center gap-3.5 p-5 lg:grid-cols-2 lg:w-fit lg:mx-auto lg:pt-12">        
+      
         <!-- Grid items -->
         <!-- Prod1-->
-        <div class="relative sm:w-[31.5rem] lg:w-[33rem]">
+        <div class="relative mb-5 sm:w-[31.5rem] lg:w-[25rem] grid:w-[33rem]">
           <!-- Pre-order sticker -->
           <div class="pre-order">
             PRE-ORDER
@@ -168,7 +168,7 @@
             <!-- Product image (main) -->
             <img class="w-full" src="src/assets/images/product/grid1/prod1/mockup-free-tXE-BU4gt9o-unsplash.jpg" alt="lip serum">
             <!-- Product image (hover) -->
-            <img class="image-hover" src="src/assets/images/product/grid1/prod1/mockup-free-CiiPxk2XKlY-unsplash.jpg" alt="lip serum">            
+            <img class="w-full absolute top-0 left-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100" src="src/assets/images/product/grid1/prod1/mockup-free-CiiPxk2XKlY-unsplash.jpg" alt="lip serum">            
           </div>
 
           <!-- Product name/Price/Description  -->
@@ -186,9 +186,9 @@
           </div>
         </div>
         <!-- Prod2 -->
-        <div class="">
+        <div class="relative mb-5 sm:w-[31.5rem] lg:w-[25rem] grid:w-[33rem]">
           <!-- Pre-order sticker -->
-          <div class="font-bold">
+          <div class="pre-order">
             PRE-ORDER
           </div>
 
@@ -196,27 +196,27 @@
             <!-- Product image (main) -->
             <img class="w-full" src="src/assets/images/product/grid1/prod2/mockup-free-m4p66uXKlW0-unsplash.jpg" alt="water bottle">
             <!-- Product image (hover) -->
-            <img class="image-hover" src="src/assets/images/product/grid1/prod2/mockup-free-RaZzLqfZ5TQ-unsplash.jpg" alt="water bottle">            
+            <img class="w-full absolute top-0 left-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100" src="src/assets/images/product/grid1/prod2/mockup-free-RaZzLqfZ5TQ-unsplash.jpg" alt="water bottle">            
           </div>
 
           <!-- Product name/Price/Description  -->
-          <div class="">
+          <div class="flex flex-col justify-end gap-0.5 mt-2 text-primary">
             <!-- Product + Price -->
-            <div class="">
+            <div class="flex justify-between">
               <h2>WATER BOTTLE</h2>
               <!-- Price/Buy Button -->
               <div class="">
-                <span>Sold Out</span>
-                <button>SHOP NOW</button>
+                <span class="sold-out">Sold Out</span>
+                <button class="hidden">SHOP NOW</button>
               </div>              
             </div>
-            <p>Notebook-shaped water bottles.</p>
+            <p class="prod-desc">Notebook-shaped water bottles.</p>
           </div>
         </div>
         <!-- Prod3 -->
-        <div class="">
+        <div class="relative mb-5 sm:w-[31.5rem] lg:w-[25rem] grid:w-[33rem]">
           <!-- Pre-order sticker -->
-          <div class="">
+          <div class="pre-order">
             PRE-ORDER
           </div>
 
@@ -224,27 +224,27 @@
             <!-- Product image (main) -->
             <img class="w-full" src="src/assets/images/product/grid1/prod3/mockup-free-SVtnyhxhPKk-unsplash.jpg" alt="Cosmetic Travel Kit">
             <!-- Product image (hover) -->
-            <img class="image-hover" src="/src/assets/images/product/grid1/prod3/mockup-free-4opLIJTgMjM-unsplash.jpg" alt="Cosmetic Travel Kit">            
+            <img class="w-full absolute top-0 left-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100" src="/src/assets/images/product/grid1/prod3/mockup-free-4opLIJTgMjM-unsplash.jpg" alt="Cosmetic Travel Kit">            
           </div>
 
           <!-- Product name/Price/Description  -->
-          <div class="">
+          <div class="flex flex-col justify-end gap-0.5 mt-2 text-primary">
             <!-- Product + Price -->
-            <div class="">
+            <div class="flex justify-between">
               <h2>COSMETIC TRAVEL KIT</h2>
               <!-- Price/Buy Button -->
               <div class="">
-                <span>Sold Out</span>
-                <button>SHOP NOW</button>
+                <span class="sold-out">Sold Out</span>
+                <button class="hidden">SHOP NOW</button>
               </div>              
             </div>
-            <p>Cosmetic travel kit that looks ominous.</p>
+            <p class="prod-desc">Cosmetic travel kit that looks ominous.</p>
           </div>
         </div>
         <!-- Prod4 -->
-        <div class="">
+        <div class="relative mb-5 sm:w-[31.5rem] lg:w-[25rem] grid:w-[33rem]">
           <!-- Pre-order sticker -->
-          <div class="">
+          <div class="pre-order">
             PRE-ORDER
           </div>
 
@@ -252,27 +252,27 @@
             <!-- Product image (main) -->
             <img class="w-full" src="src/assets/images/product/grid1/prod4/mockup-free-nbp_u-OemuE-unsplash.jpg" alt="Box">
             <!-- Product image (hover) -->
-            <img class="image-hover" src="src/assets/images/product/grid1/prod4/mockup-free-dKOM5Hwiphg-unsplash.jpg" alt="Box">            
+            <img class="w-full absolute top-0 left-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100" src="src/assets/images/product/grid1/prod4/mockup-free-dKOM5Hwiphg-unsplash.jpg" alt="Box">            
           </div>
 
           <!-- Product name/Price/Description  -->
-          <div class="">
+          <div class="flex flex-col justify-end gap-0.5 mt-2 text-primary">
             <!-- Product + Price -->
-            <div class="">
+            <div class="flex justify-between">
               <h2>BOX</h2>
               <!-- Price/Buy Button -->
               <div class="">
-                <span>Sold Out</span>
-                <button>SHOP NOW</button>
+                <span class="sold-out">Sold Out</span>
+                <button class="hidden">SHOP NOW</button>
               </div>              
             </div>
-            <p>A cardboard box you can put stuff in.</p>
+            <p class="prod-desc">A cardboard box you can put stuff in.</p>
           </div>
         </div>
         <!-- Prod5 (looooong) -->
-        <div class="">
+        <div class="relative mb-5 sm:w-[31.5rem] lg:w-[25rem] grid:w-[33rem]">
           <!-- Pre-order sticker -->
-          <div class="">
+          <div class="pre-order">
             PRE-ORDER
           </div>
 
@@ -280,21 +280,21 @@
             <!-- Product image (main) -->
             <img class="w-full" src="src/assets/images/product/grid1/prod5/mockup-free-isTYY86e514-unsplash.jpg" alt="Potato chips">
             <!-- Product image (hover) -->
-            <img class="image-hover" src="src/assets/images/product/grid1/prod5/mockup-free-BBUbUMxC_rc-unsplash.jpg" alt="Potato chips">            
+            <img class="w-full absolute top-0 left-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100" src="src/assets/images/product/grid1/prod5/mockup-free-BBUbUMxC_rc-unsplash.jpg" alt="Potato chips">            
           </div>
 
           <!-- Product name/Price/Description  -->
-          <div class="">
+          <div class="flex flex-col justify-end gap-0.5 mt-2 text-primary">
             <!-- Product + Price -->
-            <div class="">
+            <div class="flex justify-between">
               <h2>POTATO CHIPS</h2>
               <!-- Price/Buy Button -->
               <div class="">
-                <span>Sold Out</span>
-                <button>SHOP NOW</button>
+                <span class="sold-out">Sold Out</span>
+                <button class="hidden">SHOP NOW</button>
               </div>              
             </div>
-            <p>Face scrub used for scrubbing your face.</p>
+            <p class="prod-desc">Face scrub used for scrubbing your face.</p>
           </div>
         </div>
 
@@ -313,9 +313,9 @@
 
         <!-- Grid items -->
         <!-- Prod1-->
-        <div class="">
+        <div class="relative mb-5 sm:w-[31.5rem] lg:w-[25rem] grid:w-[33rem]">
           <!-- Pre-order sticker -->
-          <div class="">
+          <div class="pre-order">
             PRE-ORDER
           </div>
 
@@ -323,27 +323,27 @@
             <!-- Product image (main) -->
             <img class="w-full" src="src/assets/images/product/grid2/prod1/mockup-free-iGUjHhBdERk-unsplash.jpg" alt="Picture frame">
             <!-- Product image (hover) -->
-            <img class="image-hover" src="src/assets/images/product/grid2/prod1/mockup-free-um99wsqgd_0-unsplash.jpg" alt="Picture frame">            
+            <img class="w-full absolute top-0 left-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100" src="src/assets/images/product/grid2/prod1/mockup-free-um99wsqgd_0-unsplash.jpg" alt="Picture frame">            
           </div>
 
 
           <!-- Product name/Price/Description  -->
-          <div class="">
+          <div class="flex flex-col justify-end gap-0.5 mt-2 text-primary">
             <!-- Product + Price -->
-            <div class="">
+            <div class="flex justify-between">
               <h2>PICTURE FRAME</h2>
               <!-- Price/Buy Button -->
               <div class="">
-                <span>Sold Out</span>
-                <button>SHOP NOW</button>
+                <span class="sold-out">Sold Out</span>
+                <button class="hidden">SHOP NOW</button>
               </div>              
             </div>
           </div>
         </div>
         <!-- Prod2 -->
-        <div class="">
+        <div class="relative mb-5 sm:w-[31.5rem] lg:w-[25rem] grid:w-[33rem]">
           <!-- Pre-order sticker -->
-          <div class="">
+          <div class="pre-order">
             PRE-ORDER
           </div>
 
@@ -351,27 +351,27 @@
             <!-- Product image (main) -->
             <img class="w-full" src="src/assets/images/product/grid2/prod2/mockup-free-4iZzFDhS8X0-unsplash.jpg" alt="water bottle">
             <!-- Product image (hover) -->
-            <img class="image-hover" src="src/assets/images/product/grid2/prod2/mockup-free-lZC0QyruwK4-unsplash.jpg" alt="water bottle">            
+            <img class="w-full absolute top-0 left-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100" src="src/assets/images/product/grid2/prod2/mockup-free-lZC0QyruwK4-unsplash.jpg" alt="water bottle">            
           </div>
 
 
           <!-- Product name/Price/Description  -->
-          <div class="">
+          <div class="flex flex-col justify-end gap-0.5 mt-2 text-primary">
             <!-- Product + Price -->
-            <div class="">
+            <div class="flex justify-between">
               <h2>WATER BOTTLE</h2>
               <!-- Price/Buy Button -->
               <div class="">
-                <span>Sold Out</span>
-                <button>SHOP NOW</button>
+                <span class="sold-out">Sold Out</span>
+                <button class="hidden">SHOP NOW</button>
               </div>              
             </div>
           </div>
         </div>
         <!-- Prod3 -->
-        <div class="">
+        <div class="relative mb-5 sm:w-[31.5rem] lg:w-[25rem] grid:w-[33rem]">
           <!-- Pre-order sticker -->
-          <div class="">
+          <div class="pre-order">
             PRE-ORDER
           </div>
 
@@ -379,27 +379,27 @@
             <!-- Product image (main) -->
             <img class="w-full" src="src/assets/images/product/grid2/prod3/mockup-free-iWCJwcwxXy8-unsplash.jpg" alt="Tri-folding paper">
             <!-- Product image (hover) -->
-            <img class="image-hover" src="/src/assets/images/product/grid2/prod3/mockup-free-fs_J0oKCplE-unsplash.jpg" alt="Tri-folding paper">
+            <img class="w-full absolute top-0 left-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100" src="/src/assets/images/product/grid2/prod3/mockup-free-fs_J0oKCplE-unsplash.jpg" alt="Tri-folding paper">
           </div>
 
 
           <!-- Product name/Price/Description  -->
-          <div class="">
+          <div class="flex flex-col justify-end gap-0.5 mt-2 text-primary">
             <!-- Product + Price -->
-            <div class="">
+            <div class="flex justify-between">
               <h2>TRI-FOLDING PAPER</h2>
               <!-- Price/Buy Button -->
               <div class="">
-                <span>Sold Out</span>
-                <button>SHOP NOW</button>
+                <span class="sold-out">Sold Out</span>
+                <button class="hidden">SHOP NOW</button>
               </div>              
             </div>
           </div>
         </div>
         <!-- Prod4 -->
-        <div class="">
+        <div class="relative mb-5 sm:w-[31.5rem] lg:w-[25rem] grid:w-[33rem]">
           <!-- Pre-order sticker -->
-          <div class="">
+          <div class="pre-order">
             PRE-ORDER
           </div>
 
@@ -407,27 +407,27 @@
             <!-- Product image (main) -->
             <img class="w-full" src="src/assets/images/product/grid2/prod4/mockup-free-5nSwFqOyzHw-unsplash.jpg" alt="Cosmetic bottle">
             <!-- Product image (hover) -->
-            <img class="image-hover" src="src/assets/images/product/grid2/prod4/mockup-free-onBFHs-foB8-unsplash.jpg" alt="Cosmetic bottle">            
+            <img class="w-full absolute top-0 left-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100" src="src/assets/images/product/grid2/prod4/mockup-free-onBFHs-foB8-unsplash.jpg" alt="Cosmetic bottle">            
           </div>
 
 
           <!-- Product name/Price/Description  -->
-          <div class="">
+          <div class="flex flex-col justify-end gap-0.5 mt-2 text-primary">
             <!-- Product + Price -->
-            <div class="">
+            <div class="flex justify-between">
               <h2>COSMETIC BOTTLE</h2>
               <!-- Price/Buy Button -->
               <div class="">
-                <span>Sold Out</span>
-                <button>SHOP NOW</button>
+                <span class="sold-out">Sold Out</span>
+                <button class="hidden">SHOP NOW</button>
               </div>              
             </div>
           </div>
         </div>
         <!-- Prod5 -->
-        <div class="">
+        <div class="relative mb-5 sm:w-[31.5rem] lg:w-[25rem] grid:w-[33rem]">
           <!-- Pre-order sticker -->
-          <div class="">
+          <div class="pre-order">
             PRE-ORDER
           </div>
 
@@ -435,27 +435,27 @@
             <!-- Product image (main) -->
             <img class="w-full" src="src/assets/images/product/grid2/prod5/mockup-free-Ux2iEN0g6Dc-unsplash.jpg" alt="Cotton swab">
             <!-- Product image (hover) -->
-            <img class="image-hover" src="src/assets/images/product/grid2/prod5/mockup-free-KiVoHBe8PJo-unsplash.jpg" alt="Cotton swab">            
+            <img class="w-full absolute top-0 left-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100" src="src/assets/images/product/grid2/prod5/mockup-free-KiVoHBe8PJo-unsplash.jpg" alt="Cotton swab">            
           </div>
 
 
           <!-- Product name/Price/Description  -->
-          <div class="">
+          <div class="flex flex-col justify-end gap-0.5 mt-2 text-primary">
             <!-- Product + Price -->
-            <div class="">
+            <div class="flex justify-between">
               <h2>COTTON SWABS</h2>
               <!-- Price/Buy Button -->
               <div class="">
-                <span>Sold Out</span>
-                <button>SHOP NOW</button>
+                <span class="sold-out">Sold Out</span>
+                <button class="hidden">SHOP NOW</button>
               </div>              
             </div>
           </div>
         </div>
         <!-- Prod6-->
-        <div class="">
+        <div class="relative mb-5 sm:w-[31.5rem] lg:w-[25rem] grid:w-[33rem]">
           <!-- Pre-order sticker -->
-          <div class="">
+          <div class="pre-order">
             PRE-ORDER
           </div>
 
@@ -463,27 +463,27 @@
             <!-- Product image (main) -->
             <img class="w-full" src="src/assets/images/product/grid2/prod6/mockup-free-3v0pXrjePss-unsplash.jpg" alt="Liquid dispenser">
             <!-- Product image (hover) -->
-            <img class="image-hover" src="src/assets/images/product/grid2/prod6/mockup-free--EaQgamAoIU-unsplash.jpg" alt="Liquid dispenser">            
+            <img class="w-full absolute top-0 left-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100" src="src/assets/images/product/grid2/prod6/mockup-free--EaQgamAoIU-unsplash.jpg" alt="Liquid dispenser">            
           </div>
 
 
           <!-- Product name/Price/Description  -->
-          <div class="">
+          <div class="flex flex-col justify-end gap-0.5 mt-2 text-primary">
             <!-- Product + Price -->
-            <div class="">
+            <div class="flex justify-between">
               <h2>LIQUID DISPENSER</h2>
               <!-- Price/Buy Button -->
               <div class="">
-                <span>Sold Out</span>
-                <button>SHOP NOW</button>
+                <span class="sold-out">Sold Out</span>
+                <button class="hidden">SHOP NOW</button>
               </div>              
             </div>
           </div>
         </div>
         <!-- Prod7 -->
-        <div class="">
+        <div class="relative mb-5 sm:w-[31.5rem] lg:w-[25rem] grid:w-[33rem]">
           <!-- Pre-order sticker -->
-          <div class="">
+          <div class="pre-order">
             PRE-ORDER
           </div>
 
@@ -491,27 +491,27 @@
             <!-- Product image (main) -->
             <img class="w-full" src="src/assets/images/product/grid2/prod7/mockup-free-Fez9sPtXOzM-unsplash.jpg" alt="Square dropper bottle">
             <!-- Product image (hover) -->
-            <img class="image-hover" src="src/assets/images/product/grid2/prod7/mockup-free-SUPEwMr-iCY-unsplash.jpg" alt="Square dropper bottle">            
+            <img class="w-full absolute top-0 left-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100" src="src/assets/images/product/grid2/prod7/mockup-free-SUPEwMr-iCY-unsplash.jpg" alt="Square dropper bottle">            
           </div>
 
 
           <!-- Product name/Price/Description  -->
-          <div class="">
+          <div class="flex flex-col justify-end gap-0.5 mt-2 text-primary">
             <!-- Product + Price -->
-            <div class="">
+            <div class="flex justify-between">
               <h2>SQUARE DROPPER BOTTLE</h2>
               <!-- Price/Buy Button -->
               <div class="">
-                <span>Sold Out</span>
-                <button>SHOP NOW</button>
+                <span class="sold-out">Sold Out</span>
+                <button class="hidden">SHOP NOW</button>
               </div>              
             </div>
           </div>
         </div>
         <!-- Prod8 -->
-        <div class="">
+        <div class="relative mb-5 sm:w-[31.5rem] lg:w-[25rem] grid:w-[33rem]">
           <!-- Pre-order sticker -->
-          <div class="">
+          <div class="pre-order">
             PRE-ORDER
           </div>
 
@@ -519,27 +519,27 @@
             <!-- Product image (main) -->
             <img class="w-full" src="src/assets/images/product/grid2/prod8/mockup-free-R3fHo09P8FA-unsplash.jpg" alt="IPhone 15">
             <!-- Product image (hover) -->
-            <img class="image-hover" src="/src/assets/images/product/grid2/prod8/mockup-free-pHEtQf8Q5nk-unsplash.jpg" alt="IPhone 15">            
+            <img class="w-full absolute top-0 left-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100" src="/src/assets/images/product/grid2/prod8/mockup-free-pHEtQf8Q5nk-unsplash.jpg" alt="IPhone 15">            
           </div>
 
 
           <!-- Product name/Price/Description  -->
-          <div class="">
+          <div class="flex flex-col justify-end gap-0.5 mt-2 text-primary">
             <!-- Product + Price -->
-            <div class="">
+            <div class="flex justify-between">
               <h2>IPHONE 15 128GB</h2>
               <!-- Price/Buy Button -->
               <div class="">
-                <span>Sold Out</span>
-                <button>SHOP NOW</button>
+                <span class="sold-out">Sold Out</span>
+                <button class="hidden">SHOP NOW</button>
               </div>              
             </div>
           </div>
         </div>
         <!-- Prod9 -->
-        <div class="">
+        <div class="relative mb-5 sm:w-[31.5rem] lg:w-[25rem] grid:w-[33rem]">
           <!-- Pre-order sticker -->
-          <div class="">
+          <div class="pre-order">
             PRE-ORDER
           </div>
 
@@ -547,27 +547,27 @@
             <!-- Product image (main) -->
             <img class="w-full" src="src/assets/images/product/grid2/prod9/mockup-free-mbOA3KnbjdU-unsplash.jpg" alt="Liquid dispenser">
             <!-- Product image (hover) -->
-            <img class="image-hover" src="src/assets/images/product/grid2/prod9/mockup-free-RbN6PswtkKk-unsplash.jpg" alt="Liquid dispenser">            
+            <img class="w-full absolute top-0 left-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100" src="src/assets/images/product/grid2/prod9/mockup-free-RbN6PswtkKk-unsplash.jpg" alt="Liquid dispenser">            
           </div>
 
 
           <!-- Product name/Price/Description  -->
-          <div class="">
+          <div class="flex flex-col justify-end gap-0.5 mt-2 text-primary">
             <!-- Product + Price -->
-            <div class="">
+            <div class="flex justify-between">
               <h2>LIQUID DISPENSER</h2>
               <!-- Price/Buy Button -->
               <div class="">
-                <span>Sold Out</span>
-                <button>SHOP NOW</button>
+                <span class="sold-out">Sold Out</span>
+                <button class="hidden">SHOP NOW</button>
               </div>              
             </div>
           </div>
         </div>
         <!-- Prod10 -->
-        <div class="">
+        <div class="relative mb-5 sm:w-[31.5rem] lg:w-[25rem] grid:w-[33rem]">
           <!-- Pre-order sticker -->
-          <div class="">
+          <div class="pre-order">
             PRE-ORDER
           </div>
 
@@ -575,27 +575,27 @@
             <!-- Product image (main) -->
             <img class="w-full" src="src/assets/images/product/grid2/prod10/mockup-free-fQg-kHuqyPE-unsplash.jpg" alt="Lotion">
             <!-- Product image (hover) -->
-            <img class="image-hover" src="src/assets/images/product/grid2/prod10/mockup-free-dSN04rvRHh0-unsplash.jpg" alt="Lotion">            
+            <img class="w-full absolute top-0 left-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100" src="src/assets/images/product/grid2/prod10/mockup-free-dSN04rvRHh0-unsplash.jpg" alt="Lotion">            
           </div>
 
 
           <!-- Product name/Price/Description  -->
-          <div class="">
+          <div class="flex flex-col justify-end gap-0.5 mt-2 text-primary">
             <!-- Product + Price -->
-            <div class="">
+            <div class="flex justify-between">
               <h2>LOTION</h2>
               <!-- Price/Buy Button -->
               <div class="">
-                <span>Sold Out</span>
-                <button>SHOP NOW</button>
+                <span class="sold-out">Sold Out</span>
+                <button class="hidden">SHOP NOW</button>
               </div>              
             </div>
           </div>
         </div>
         <!-- Prod11 -->
-        <div class="">
+        <div class="relative mb-5 sm:w-[31.5rem] lg:w-[25rem] grid:w-[33rem]">
           <!-- Pre-order sticker -->
-          <div class="">
+          <div class="pre-order">
             PRE-ORDER
           </div>
 
@@ -603,27 +603,27 @@
             <!-- Product image (main) -->
             <img class="w-full" src="src/assets/images/product/grid2/prod11/mockup-free-KV6ssi1shF0-unsplash.jpg" alt="Box">
             <!-- Product image (hover) -->
-            <img class="image-hover" src="src/assets/images/product/grid2/prod11/mockup-free-_AkQ57-2StI-unsplash.jpg" alt="Box">            
+            <img class="w-full absolute top-0 left-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100" src="src/assets/images/product/grid2/prod11/mockup-free-_AkQ57-2StI-unsplash.jpg" alt="Box">            
           </div>
 
 
           <!-- Product name/Price/Description  -->
-          <div class="">
+          <div class="flex flex-col justify-end gap-0.5 mt-2 text-primary">
             <!-- Product + Price -->
-            <div class="">
+            <div class="flex justify-between">
               <h2>BOX</h2>
               <!-- Price/Buy Button -->
               <div class="">
-                <span>Sold Out</span>
-                <button>SHOP NOW</button>
+                <span class="sold-out">Sold Out</span>
+                <button class="hidden">SHOP NOW</button>
               </div>              
             </div>
           </div>
         </div>
         <!-- Prod12 -->
-        <div class="">
+        <div class="relative mb-5 sm:w-[31.5rem] lg:w-[25rem] grid:w-[33rem]">
           <!-- Pre-order sticker -->
-          <div class="">
+          <div class="pre-order">
             PRE-ORDER
           </div>
 
@@ -631,19 +631,19 @@
             <!-- Product image (main) -->
             <img class="w-full" src="src/assets/images/product/grid2/prod12/mockup-free-ZK9Zvi55lPM-unsplash.jpg" alt="Airpods case">
             <!-- Product image (hover) -->
-            <img class="image-hover" src="src/assets/images/product/grid2/prod12/mockup-free-SLUg2UHeqPs-unsplash.jpg" alt="Airpods case">            
+            <img class="w-full absolute top-0 left-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100" src="src/assets/images/product/grid2/prod12/mockup-free-SLUg2UHeqPs-unsplash.jpg" alt="Airpods case">            
           </div>
 
 
           <!-- Product name/Price/Description  -->
-          <div class="">
+          <div class="flex flex-col justify-end gap-0.5 mt-2 text-primary">
             <!-- Product + Price -->
-            <div class="">
+            <div class="flex justify-between">
               <h2>SKULL AIRPODS CASE</h2>
               <!-- Price/Buy Button -->
               <div class="">
-                <span>Sold Out</span>
-                <button>SHOP NOW</button>
+                <span class="sold-out">Sold Out</span>
+                <button class="hidden">SHOP NOW</button>
               </div>              
             </div>
           </div>

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
   <body>
 
     <!-- Background overlay for sidebars -->
-    <div id="sidebar-overlay" class="fixed z-40 inset-0 bg-black/70 opacity-0 invisible transition-opacity duration-400"></div>
+    <div id="sidebar-overlay" class="overlay invisible bg-black/70 opacity-0 "></div>
 
     <!-- Fixed navigational top bar -->
     <nav class="flex justify-between items-center fixed z-40 top-1.5 left-1.5 right-1.5 pr-4 text-accent bg-primary sm:top-3.5 sm:left-3.5 sm:right-3.5">
@@ -78,7 +78,7 @@
     </nav>
   
     <!-- Mobile menu sidenav -->
-    <nav id="sidebar" class="flex flex-col gap-3 z-50 fixed top-0 left-0 min-w-[22rem] h-full p-2 text-accent bg-primary transform -translate-x-full transition-transform duration-300 ease-in-out sm:p-5">
+    <nav id="sidebar" class="mobile-menu flex transform -translate-x-full">
 
       <div class="flex justify-between">
         <!-- [Left] Logo + Title -->
@@ -154,20 +154,22 @@
       </header>
 
       <!-- First grid -->
-      <section id="grid-featured" class="hidden">
+      <section id="grid-featured" class="grid grid-cols-1 px-5 pt-5">
         
         <!-- Grid items -->
         <!-- Prod1-->
-        <div class="">
+        <div class="relative">
           <!-- Pre-order sticker -->
-          <div class="">
+          <div class="absolute z-30 bg-ribbon">
             PRE-ORDER
           </div>
 
-          <!-- Product image (main) -->
-          <img src="src/assets/images/product/grid1/prod1/mockup-free-tXE-BU4gt9o-unsplash.jpg" alt="lip serum">
-          <!-- Product image (hover) -->
-          <img src="src/assets/images/product/grid1/prod1/mockup-free-CiiPxk2XKlY-unsplash.jpg" alt="lip serum">
+          <div class="group relative">
+            <!-- Product image (main) -->
+            <img class="w-full" src="src/assets/images/product/grid1/prod1/mockup-free-tXE-BU4gt9o-unsplash.jpg" alt="lip serum">
+            <!-- Product image (hover) -->
+            <img class="w-full absolute top-0 left-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100" src="src/assets/images/product/grid1/prod1/mockup-free-CiiPxk2XKlY-unsplash.jpg" alt="lip serum">            
+          </div>
 
           <!-- Product name/Price/Description  -->
           <div class="">
@@ -190,10 +192,12 @@
             PRE-ORDER
           </div>
 
-          <!-- Product image (main) -->
-          <img src="src/assets/images/product/grid1/prod2/mockup-free-m4p66uXKlW0-unsplash.jpg" alt="water bottle">
-          <!-- Product image (hover) -->
-          <img src="src/assets/images/product/grid1/prod2/mockup-free-RaZzLqfZ5TQ-unsplash.jpg" alt="water bottle">
+          <div class="group relative">
+            <!-- Product image (main) -->
+            <img class="w-full" src="src/assets/images/product/grid1/prod2/mockup-free-m4p66uXKlW0-unsplash.jpg" alt="water bottle">
+            <!-- Product image (hover) -->
+            <img class="w-full absolute top-0 left-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100" src="src/assets/images/product/grid1/prod2/mockup-free-RaZzLqfZ5TQ-unsplash.jpg" alt="water bottle">            
+          </div>
 
           <!-- Product name/Price/Description  -->
           <div class="">
@@ -216,10 +220,12 @@
             PRE-ORDER
           </div>
 
-          <!-- Product image (main) -->
-          <img src="src/assets/images/product/grid1/prod3/mockup-free-SVtnyhxhPKk-unsplash.jpg" alt="Cosmetic Travel Kit">
-          <!-- Product image (hover) -->
-          <img src="/src/assets/images/product/grid1/prod3/mockup-free-4opLIJTgMjM-unsplash.jpg" alt="Cosmetic Travel Kit">
+          <div class="group relative">
+            <!-- Product image (main) -->
+            <img class="w-full" src="src/assets/images/product/grid1/prod3/mockup-free-SVtnyhxhPKk-unsplash.jpg" alt="Cosmetic Travel Kit">
+            <!-- Product image (hover) -->
+            <img class="w-full absolute top-0 left-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100" src="/src/assets/images/product/grid1/prod3/mockup-free-4opLIJTgMjM-unsplash.jpg" alt="Cosmetic Travel Kit">            
+          </div>
 
           <!-- Product name/Price/Description  -->
           <div class="">
@@ -242,10 +248,12 @@
             PRE-ORDER
           </div>
 
-          <!-- Product image (main) -->
-          <img src="src/assets/images/product/grid1/prod4/mockup-free-nbp_u-OemuE-unsplash.jpg" alt="Box">
-          <!-- Product image (hover) -->
-          <img src="src/assets/images/product/grid1/prod4/mockup-free-dKOM5Hwiphg-unsplash.jpg" alt="Box">
+          <div class="group relative">
+            <!-- Product image (main) -->
+            <img class="w-full" src="src/assets/images/product/grid1/prod4/mockup-free-nbp_u-OemuE-unsplash.jpg" alt="Box">
+            <!-- Product image (hover) -->
+            <img class="w-full absolute top-0 left-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100" src="src/assets/images/product/grid1/prod4/mockup-free-dKOM5Hwiphg-unsplash.jpg" alt="Box">            
+          </div>
 
           <!-- Product name/Price/Description  -->
           <div class="">
@@ -268,10 +276,12 @@
             PRE-ORDER
           </div>
 
-          <!-- Product image (main) -->
-          <img src="src/assets/images/product/grid1/prod5/mockup-free-isTYY86e514-unsplash.jpg" alt="Potato chips">
-          <!-- Product image (hover) -->
-          <img src="src/assets/images/product/grid1/prod5/mockup-free-BBUbUMxC_rc-unsplash.jpg" alt="Potato chips">
+          <div class="group relative">
+            <!-- Product image (main) -->
+            <img class="w-full" src="src/assets/images/product/grid1/prod5/mockup-free-isTYY86e514-unsplash.jpg" alt="Potato chips">
+            <!-- Product image (hover) -->
+            <img class="w-full absolute top-0 left-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100" src="src/assets/images/product/grid1/prod5/mockup-free-BBUbUMxC_rc-unsplash.jpg" alt="Potato chips">            
+          </div>
 
           <!-- Product name/Price/Description  -->
           <div class="">
@@ -299,7 +309,7 @@
       </section>
 
       <!-- Second grid -->
-      <section class="hidden">
+      <section class="">
 
         <!-- Grid items -->
         <!-- Prod1-->
@@ -309,10 +319,13 @@
             PRE-ORDER
           </div>
 
-          <!-- Product image (main) -->
-          <img src="src/assets/images/product/grid2/prod1/mockup-free-iGUjHhBdERk-unsplash.jpg" alt="Picture frame">
-          <!-- Product image (hover) -->
-          <img src="src/assets/images/product/grid2/prod1/mockup-free-um99wsqgd_0-unsplash.jpg" alt="Picture frame">
+          <div class="group relative">
+            <!-- Product image (main) -->
+            <img class="w-full" src="src/assets/images/product/grid2/prod1/mockup-free-iGUjHhBdERk-unsplash.jpg" alt="Picture frame">
+            <!-- Product image (hover) -->
+            <img class="w-full absolute top-0 left-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100" src="src/assets/images/product/grid2/prod1/mockup-free-um99wsqgd_0-unsplash.jpg" alt="Picture frame">            
+          </div>
+
 
           <!-- Product name/Price/Description  -->
           <div class="">
@@ -334,10 +347,13 @@
             PRE-ORDER
           </div>
 
-          <!-- Product image (main) -->
-          <img src="src/assets/images/product/grid2/prod2/mockup-free-4iZzFDhS8X0-unsplash.jpg" alt="water bottle">
-          <!-- Product image (hover) -->
-          <img src="src/assets/images/product/grid2/prod2/mockup-free-lZC0QyruwK4-unsplash.jpg" alt="water bottle">
+          <div class="group relative">
+            <!-- Product image (main) -->
+            <img class="w-full" src="src/assets/images/product/grid2/prod2/mockup-free-4iZzFDhS8X0-unsplash.jpg" alt="water bottle">
+            <!-- Product image (hover) -->
+            <img class="w-full absolute top-0 left-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100" src="src/assets/images/product/grid2/prod2/mockup-free-lZC0QyruwK4-unsplash.jpg" alt="water bottle">            
+          </div>
+
 
           <!-- Product name/Price/Description  -->
           <div class="">
@@ -359,10 +375,13 @@
             PRE-ORDER
           </div>
 
-          <!-- Product image (main) -->
-          <img src="src/assets/images/product/grid2/prod3/mockup-free-iWCJwcwxXy8-unsplash.jpg" alt="Tri-folding paper">
-          <!-- Product image (hover) -->
-          <img src="/src/assets/images/product/grid2/prod3/mockup-free-fs_J0oKCplE-unsplash.jpg" alt="Tri-folding paper">
+          <div class="group relative">
+            <!-- Product image (main) -->
+            <img class="w-full" src="src/assets/images/product/grid2/prod3/mockup-free-iWCJwcwxXy8-unsplash.jpg" alt="Tri-folding paper">
+            <!-- Product image (hover) -->
+            <img class="w-full absolute top-0 left-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100" src="/src/assets/images/product/grid2/prod3/mockup-free-fs_J0oKCplE-unsplash.jpg" alt="Tri-folding paper">
+          </div>
+
 
           <!-- Product name/Price/Description  -->
           <div class="">
@@ -384,10 +403,13 @@
             PRE-ORDER
           </div>
 
-          <!-- Product image (main) -->
-          <img src="src/assets/images/product/grid2/prod4/mockup-free-5nSwFqOyzHw-unsplash.jpg" alt="Cosmetic bottle">
-          <!-- Product image (hover) -->
-          <img src="src/assets/images/product/grid2/prod4/mockup-free-onBFHs-foB8-unsplash.jpg" alt="Cosmetic bottle">
+          <div class="group relative">
+            <!-- Product image (main) -->
+            <img class="w-full" src="src/assets/images/product/grid2/prod4/mockup-free-5nSwFqOyzHw-unsplash.jpg" alt="Cosmetic bottle">
+            <!-- Product image (hover) -->
+            <img class="w-full absolute top-0 left-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100" src="src/assets/images/product/grid2/prod4/mockup-free-onBFHs-foB8-unsplash.jpg" alt="Cosmetic bottle">            
+          </div>
+
 
           <!-- Product name/Price/Description  -->
           <div class="">
@@ -409,10 +431,13 @@
             PRE-ORDER
           </div>
 
-          <!-- Product image (main) -->
-          <img src="src/assets/images/product/grid2/prod5/mockup-free-Ux2iEN0g6Dc-unsplash.jpg" alt="Cotton swab">
-          <!-- Product image (hover) -->
-          <img src="src/assets/images/product/grid2/prod5/mockup-free-KiVoHBe8PJo-unsplash.jpg" alt="Cotton swab">
+          <div class="group relative">
+            <!-- Product image (main) -->
+            <img class="w-full" src="src/assets/images/product/grid2/prod5/mockup-free-Ux2iEN0g6Dc-unsplash.jpg" alt="Cotton swab">
+            <!-- Product image (hover) -->
+            <img class="w-full absolute top-0 left-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100" src="src/assets/images/product/grid2/prod5/mockup-free-KiVoHBe8PJo-unsplash.jpg" alt="Cotton swab">            
+          </div>
+
 
           <!-- Product name/Price/Description  -->
           <div class="">
@@ -434,10 +459,13 @@
             PRE-ORDER
           </div>
 
-          <!-- Product image (main) -->
-          <img src="src/assets/images/product/grid2/prod6/mockup-free-3v0pXrjePss-unsplash.jpg" alt="Liquid dispenser">
-          <!-- Product image (hover) -->
-          <img src="src/assets/images/product/grid2/prod6/mockup-free--EaQgamAoIU-unsplash.jpg" alt="Liquid dispenser">
+          <div class="group relative">
+            <!-- Product image (main) -->
+            <img class="w-full" src="src/assets/images/product/grid2/prod6/mockup-free-3v0pXrjePss-unsplash.jpg" alt="Liquid dispenser">
+            <!-- Product image (hover) -->
+            <img class="w-full absolute top-0 left-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100" src="src/assets/images/product/grid2/prod6/mockup-free--EaQgamAoIU-unsplash.jpg" alt="Liquid dispenser">            
+          </div>
+
 
           <!-- Product name/Price/Description  -->
           <div class="">
@@ -459,10 +487,13 @@
             PRE-ORDER
           </div>
 
-          <!-- Product image (main) -->
-          <img src="src/assets/images/product/grid2/prod7/mockup-free-Fez9sPtXOzM-unsplash.jpg" alt="Square dropper bottle">
-          <!-- Product image (hover) -->
-          <img src="src/assets/images/product/grid2/prod7/mockup-free-SUPEwMr-iCY-unsplash.jpg" alt="Square dropper bottle">
+          <div class="group relative">
+            <!-- Product image (main) -->
+            <img class="w-full" src="src/assets/images/product/grid2/prod7/mockup-free-Fez9sPtXOzM-unsplash.jpg" alt="Square dropper bottle">
+            <!-- Product image (hover) -->
+            <img class="w-full absolute top-0 left-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100" src="src/assets/images/product/grid2/prod7/mockup-free-SUPEwMr-iCY-unsplash.jpg" alt="Square dropper bottle">            
+          </div>
+
 
           <!-- Product name/Price/Description  -->
           <div class="">
@@ -484,10 +515,13 @@
             PRE-ORDER
           </div>
 
-          <!-- Product image (main) -->
-          <img src="src/assets/images/product/grid2/prod8/mockup-free-R3fHo09P8FA-unsplash.jpg" alt="IPhone 15">
-          <!-- Product image (hover) -->
-          <img src="/src/assets/images/product/grid2/prod8/mockup-free-pHEtQf8Q5nk-unsplash.jpg" alt="IPhone 15">
+          <div class="group relative">
+            <!-- Product image (main) -->
+            <img class="w-full" src="src/assets/images/product/grid2/prod8/mockup-free-R3fHo09P8FA-unsplash.jpg" alt="IPhone 15">
+            <!-- Product image (hover) -->
+            <img class="w-full absolute top-0 left-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100" src="/src/assets/images/product/grid2/prod8/mockup-free-pHEtQf8Q5nk-unsplash.jpg" alt="IPhone 15">            
+          </div>
+
 
           <!-- Product name/Price/Description  -->
           <div class="">
@@ -509,10 +543,13 @@
             PRE-ORDER
           </div>
 
-          <!-- Product image (main) -->
-          <img src="src/assets/images/product/grid2/prod9/mockup-free-mbOA3KnbjdU-unsplash.jpg" alt="Liquid dispenser">
-          <!-- Product image (hover) -->
-          <img src="src/assets/images/product/grid2/prod9/mockup-free-RbN6PswtkKk-unsplash.jpg" alt="Liquid dispenser">
+          <div class="group relative">
+            <!-- Product image (main) -->
+            <img class="w-full" src="src/assets/images/product/grid2/prod9/mockup-free-mbOA3KnbjdU-unsplash.jpg" alt="Liquid dispenser">
+            <!-- Product image (hover) -->
+            <img class="w-full absolute top-0 left-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100" src="src/assets/images/product/grid2/prod9/mockup-free-RbN6PswtkKk-unsplash.jpg" alt="Liquid dispenser">            
+          </div>
+
 
           <!-- Product name/Price/Description  -->
           <div class="">
@@ -534,10 +571,13 @@
             PRE-ORDER
           </div>
 
-          <!-- Product image (main) -->
-          <img src="src/assets/images/product/grid2/prod10/mockup-free-fQg-kHuqyPE-unsplash.jpg" alt="Lotion">
-          <!-- Product image (hover) -->
-          <img src="src/assets/images/product/grid2/prod10/mockup-free-dSN04rvRHh0-unsplash.jpg" alt="Lotion">
+          <div class="group relative">
+            <!-- Product image (main) -->
+            <img class="w-full" src="src/assets/images/product/grid2/prod10/mockup-free-fQg-kHuqyPE-unsplash.jpg" alt="Lotion">
+            <!-- Product image (hover) -->
+            <img class="w-full absolute top-0 left-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100" src="src/assets/images/product/grid2/prod10/mockup-free-dSN04rvRHh0-unsplash.jpg" alt="Lotion">            
+          </div>
+
 
           <!-- Product name/Price/Description  -->
           <div class="">
@@ -559,10 +599,13 @@
             PRE-ORDER
           </div>
 
-          <!-- Product image (main) -->
-          <img src="src/assets/images/product/grid2/prod11/mockup-free-KV6ssi1shF0-unsplash.jpg" alt="Box">
-          <!-- Product image (hover) -->
-          <img src="src/assets/images/product/grid2/prod11/mockup-free-_AkQ57-2StI-unsplash.jpg" alt="Box">
+          <div class="group relative">
+            <!-- Product image (main) -->
+            <img class="w-full" src="src/assets/images/product/grid2/prod11/mockup-free-KV6ssi1shF0-unsplash.jpg" alt="Box">
+            <!-- Product image (hover) -->
+            <img class="w-full absolute top-0 left-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100" src="src/assets/images/product/grid2/prod11/mockup-free-_AkQ57-2StI-unsplash.jpg" alt="Box">            
+          </div>
+
 
           <!-- Product name/Price/Description  -->
           <div class="">
@@ -584,10 +627,13 @@
             PRE-ORDER
           </div>
 
-          <!-- Product image (main) -->
-          <img src="src/assets/images/product/grid2/prod12/mockup-free-ZK9Zvi55lPM-unsplash.jpg" alt="Airpods case">
-          <!-- Product image (hover) -->
-          <img src="src/assets/images/product/grid2/prod12/mockup-free-SLUg2UHeqPs-unsplash.jpg" alt="Airpods case">
+          <div class="group relative">
+            <!-- Product image (main) -->
+            <img class="w-full" src="src/assets/images/product/grid2/prod12/mockup-free-ZK9Zvi55lPM-unsplash.jpg" alt="Airpods case">
+            <!-- Product image (hover) -->
+            <img class="w-full absolute top-0 left-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100" src="src/assets/images/product/grid2/prod12/mockup-free-SLUg2UHeqPs-unsplash.jpg" alt="Airpods case">            
+          </div>
+
 
           <!-- Product name/Price/Description  -->
           <div class="">

--- a/src/style.css
+++ b/src/style.css
@@ -23,6 +23,9 @@
     --color-hover: #E28F74; /* Hovered accent links */
     --color-flavortext: #080b1b; /* Hovered primary links, 'PRE-ORDER' text, dropdown item text */
 
+    /* Breakpoints */
+    --breakpoint-grid: 70rem; /* ONLY for product grid when transitioning to cols-2! */
+
 }
 
 /* ===================== */

--- a/src/style.css
+++ b/src/style.css
@@ -18,6 +18,7 @@
     /* Colors */
     --color-primary: #1A2456; /* Nav, product title, price */
     --color-background: #f0efed; /* Main background color (off-white) */
+    --color-ribbon: #FF8D6B; /* Pre-order text */
     --color-accent: #EFC2B3; /* Nav links, icons, hero text, footer text */
     --color-hover: #E28F74; /* Hovered accent links */
     --color-flavortext: #080b1b; /* Hovered primary links, 'PRE-ORDER' text, dropdown item text */
@@ -46,7 +47,7 @@
 /* Shared classes */
 @layer utilities {
 
-    /* General */
+    /* ========== GENERAL ========== */
     html {
         scroll-behavior: smooth;
     }
@@ -63,7 +64,8 @@
         w-full min-h-screen;
     }
 
-    /* Hero background images */
+    /* ========== HERO ========== */
+    /* Hero images */
     .hero-first {
         @apply
         bg-cover bg-center bg-no-repeat bg-black/70 bg-blend-darken
@@ -75,8 +77,7 @@
         bg-[url(src/assets/images/joyce-g-Jqv4HkLWc6g-unsplash.jpg)]
         lg:bg-[center_75%];
     }
-
-    /* Headings */
+    /* Hero headings */
     .title {
         @apply
         font-heading text-sm tracking-[0.12em]
@@ -95,6 +96,7 @@
         sm:text-lg;
     }
 
+    /* ========== LINKS ========== */
     /* Links */
     .nav-link {
         @apply
@@ -125,6 +127,43 @@
         after:border-t-current
         after:border-l-transparent
         after:border-r-transparent;
+    }
+
+    /* ========== NAVIGATION ========== */
+    /* Navigational top bar */
+    .topnav {
+        @apply
+        flex justify-between items-center fixed z-40 
+        top-1.5 left-1.5 right-1.5 pr-4 
+        text-accent 
+        bg-primary 
+        sm:top-3.5 sm:left-3.5 sm:right-3.5;
+    }
+    /* Mobile menu sidenav */
+    .mobile-menu {
+        @apply
+        flex-col gap-3 z-50 fixed
+        top-0 left-0 min-w-[22rem] h-full p-2
+        text-accent 
+        bg-primary
+        transition-transform duration-300 ease-in-out
+        sm:p-5;
+    }
+    /* Overlay for mobile menu */
+    .overlay {
+        @apply
+        fixed z-40 
+        inset-0 
+        transition-opacity duration-400;
+    }
+
+    /* ========== PRDOUCT IMAGE HOVER ========== */
+    .image-hover {
+        @apply
+        absolute 
+        w-full top-0 left-0 
+        opacity-0 transition-opacity duration-300 
+        group-hover:opacity-100;
     }
 
 }

--- a/src/style.css
+++ b/src/style.css
@@ -157,7 +157,32 @@
         transition-opacity duration-400;
     }
 
-    /* ========== PRDOUCT IMAGE HOVER ========== */
+    /* ========== PRDOUCTS ========== */
+    /* Product name */
+    h2 {
+        @apply
+        font-heading tracking-[0.12em]
+        sm:text-lg;
+    }
+    /* Pre-order ribbon */
+    .pre-order {
+        @apply
+        absolute z-30 
+        top-5 right-0 px-3.5 py-[5px] 
+        font-heading tracking-widest text-xs text-flavortext 
+        bg-ribbon;
+    }
+    /* Product description */
+    .prod-desc {
+        @apply
+        font-light text-xs
+        sm:text-sm;
+    }
+    .sold-out {
+        @apply
+        font-light text-sm text-gray-500;
+    }
+    /* Product image hover */
     .image-hover {
         @apply
         absolute 


### PR DESCRIPTION
## What's in this PR?

This PR styles both product grids.

It's not exactly one-to-one with the original website, mostly due to the Monogram site having more breakpoints for specific grid sizes. However it turns out pretty nice either way.

I did add a specific breakpoint for the first grid transitioning to 2 columns. For the second grid, I skipped a specific breakpoint present in the original site, also pertaining to the transition to 2 columns, that made the products slightly smaller, but I just skipped straight to the larger sizes.